### PR TITLE
docs: clarify add-on installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,16 @@
 
 This repository contains the Multi-DDNS add-on for Home Assistant.
 
+> **Important**: This is a Home Assistant *add-on* repository. It cannot be
+added through [HACS](https://hacs.xyz), which only manages integrations and
+frontend plugins. To use this project, add this repository to the Home
+Assistant add-on store instead.
+
+## Repository structure
+
+This repository follows the Home Assistant add-on repository format:
+
+- `repository.yaml` – repository metadata
+- `multiddns/` – Multi-DDNS add-on
+
 See [multiddns](./multiddns) for the add-on documentation and source.

--- a/multiddns/README.md
+++ b/multiddns/README.md
@@ -1,6 +1,6 @@
 # Home Assistant Add-on: Multi-DDNS
 
-Automatically update Home Assistant multiple DDNS IPs address with integrated HTTPS support via Let's Encrypt. it currently supports the following DDNS services:
+Automatically update Home Assistant multiple DDNS IPs address with integrated HTTPS support via Let's Encrypt. It is distributed as a Home Assistant **add-on** and must be installed from the add-on store (not via HACS). It currently supports the following DDNS services:
  - [Duck DNS][duckdns]
  - [Dynu DNS][dynudns]
 

--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,0 @@
-{
-  "name": "Multi-DDNS Add-on Repository",
-  "url": "https://github.com/CaseyRo/dynudns",
-  "maintainer": "Casey <mail@casey.berlin>"
-}

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,0 +1,3 @@
+name: Multi-DDNS Add-on Repository
+url: https://github.com/CaseyRo/dynudns
+maintainer: Casey <mail@casey.berlin>


### PR DESCRIPTION
## Summary
- clarify that the project is a Home Assistant add-on and not a HACS integration
- update add-on README with installation note
- add `repository.yaml` metadata and document repository structure

## Testing
- `bash -n multiddns/app/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b5739013bc8330a446b158ab13b40d