### PR TITLE
Add config flow for Multi-DDNS integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,20 +11,16 @@ This repository hosts the **Multi-DDNS** integration for Home Assistant. It expo
 
 ## Usage
 
-Add the following to your `configuration.yaml` to enable the sensor and configure domain updates:
+Configure the integration via the Home Assistant UI:
 
-```yaml
-sensor:
-  - platform: multiddns
-    domains:
-      - myhome.duckdns.org
-      - example.dynu.net
-    duck_token: !secret duckdns_token     # Optional, required for DuckDNS domains
-    dynu_token: !secret dynu_api_token    # Optional, required for Dynu domains
-    scan_interval: 300                    # Optional, seconds between updates
-```
+1. Go to **Settings → Devices & Services → Add Integration**.
+2. Search for **Multi-DDNS**.
+3. Fill out the form with your domains (one per line), optional Dynu and DuckDNS tokens,
+   IP endpoints, wildcard toggle and update interval.
+4. After setup, use the **Options** button on the integration to adjust settings later.
 
-The sensor `sensor.external_ip` will show your current external IP address and update the configured domains on each interval.
+The integration creates a sensor `sensor.external_ip` that shows your current
+external IP address and updates the configured domains on each interval.
 
 ## Certificate management
 

--- a/custom_components/multiddns/__init__.py
+++ b/custom_components/multiddns/__init__.py
@@ -8,6 +8,9 @@ import asyncio
 from pathlib import Path
 
 from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.config_entries import ConfigEntry
+
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -59,6 +62,17 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
                 )
 
     hass.services.async_register(
-        "multiddns", "issue_certificate", issue_certificate
+        DOMAIN, "issue_certificate", issue_certificate
     )
     return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Multi-DDNS from a config entry."""
+    await hass.config_entries.async_forward_entry_setup(entry, "sensor")
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a Multi-DDNS config entry."""
+    return await hass.config_entries.async_forward_entry_unload(entry, "sensor")

--- a/custom_components/multiddns/config_flow.py
+++ b/custom_components/multiddns/config_flow.py
@@ -1,0 +1,95 @@
+"""Config flow for Multi-DDNS integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.core import callback
+
+from .const import (
+    DOMAIN,
+    CONF_DOMAINS,
+    CONF_DYNU_TOKEN,
+    CONF_DUCK_TOKEN,
+    CONF_IPV4,
+    CONF_IPV6,
+    CONF_WILDCARD,
+    CONF_UPDATE_INTERVAL,
+    DEFAULT_IPV4,
+    DEFAULT_IPV6,
+    DEFAULT_UPDATE_INTERVAL,
+)
+
+
+class MultiDDNSConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Multi-DDNS."""
+
+    VERSION = 1
+
+    async def async_step_user(self, user_input: dict[str, Any] | None = None):
+        if user_input is not None:
+            user_input[CONF_DOMAINS] = [
+                d.strip() for d in user_input[CONF_DOMAINS].splitlines() if d.strip()
+            ]
+            return self.async_create_entry(title="Multi-DDNS", data=user_input)
+
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_DOMAINS): str,
+                vol.Optional(CONF_DYNU_TOKEN): str,
+                vol.Optional(CONF_DUCK_TOKEN): str,
+                vol.Optional(CONF_IPV4, default=DEFAULT_IPV4): str,
+                vol.Optional(CONF_IPV6, default=DEFAULT_IPV6): str,
+                vol.Optional(CONF_WILDCARD, default=False): bool,
+                vol.Optional(
+                    CONF_UPDATE_INTERVAL, default=DEFAULT_UPDATE_INTERVAL
+                ): int,
+            }
+        )
+        return self.async_show_form(step_id="user", data_schema=data_schema)
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: config_entries.ConfigEntry):
+        return MultiDDNSOptionsFlow(config_entry)
+
+
+class MultiDDNSOptionsFlow(config_entries.OptionsFlow):
+    """Handle options for Multi-DDNS."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input: dict[str, Any] | None = None):
+        if user_input is not None:
+            user_input[CONF_DOMAINS] = [
+                d.strip() for d in user_input[CONF_DOMAINS].splitlines() if d.strip()
+            ]
+            return self.async_create_entry(data=user_input)
+
+        data = {**self.config_entry.data, **self.config_entry.options}
+        data_schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_DOMAINS,
+                    default="\n".join(data.get(CONF_DOMAINS, [])),
+                ): str,
+                vol.Optional(
+                    CONF_DYNU_TOKEN, default=data.get(CONF_DYNU_TOKEN, "")
+                ): str,
+                vol.Optional(
+                    CONF_DUCK_TOKEN, default=data.get(CONF_DUCK_TOKEN, "")
+                ): str,
+                vol.Optional(CONF_IPV4, default=data.get(CONF_IPV4, DEFAULT_IPV4)): str,
+                vol.Optional(CONF_IPV6, default=data.get(CONF_IPV6, DEFAULT_IPV6)): str,
+                vol.Optional(CONF_WILDCARD, default=data.get(CONF_WILDCARD, False)): bool,
+                vol.Optional(
+                    CONF_UPDATE_INTERVAL,
+                    default=data.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL),
+                ): int,
+            }
+        )
+        return self.async_show_form(step_id="init", data_schema=data_schema)

--- a/custom_components/multiddns/const.py
+++ b/custom_components/multiddns/const.py
@@ -1,0 +1,20 @@
+"""Constants for Multi-DDNS integration."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+DOMAIN = "multiddns"
+
+CONF_DOMAINS = "domains"
+CONF_DYNU_TOKEN = "dynu_token"
+CONF_DUCK_TOKEN = "duck_token"
+CONF_IPV4 = "ipv4"
+CONF_IPV6 = "ipv6"
+CONF_WILDCARD = "wildcard_alias"
+CONF_UPDATE_INTERVAL = "update_interval"
+
+DEFAULT_IPV4 = "https://ipv4.text.wtfismyip.com"
+DEFAULT_IPV6 = "https://ipv6.text.wtfismyip.com"
+DEFAULT_UPDATE_INTERVAL = 5  # minutes
+DEFAULT_SCAN_INTERVAL = timedelta(minutes=DEFAULT_UPDATE_INTERVAL)

--- a/custom_components/multiddns/manifest.json
+++ b/custom_components/multiddns/manifest.json
@@ -5,5 +5,6 @@
   "documentation": "https://github.com/CaseyRo/dynudns",
   "requirements": [],
   "codeowners": ["@CaseyRo"],
-  "iot_class": "cloud_polling"
+  "iot_class": "cloud_polling",
+  "config_flow": true
 }

--- a/custom_components/multiddns/sensor.py
+++ b/custom_components/multiddns/sensor.py
@@ -14,16 +14,19 @@ from homeassistant.const import CONF_SCAN_INTERVAL
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-CONF_DOMAINS = "domains"
-CONF_DYNU_TOKEN = "dynu_token"
-CONF_DUCK_TOKEN = "duck_token"
-CONF_IPV4 = "ipv4"
-CONF_IPV6 = "ipv6"
-CONF_WILDCARD = "wildcard_alias"
-
-DEFAULT_IPV4 = "https://ipv4.text.wtfismyip.com"
-DEFAULT_IPV6 = "https://ipv6.text.wtfismyip.com"
-DEFAULT_INTERVAL = timedelta(minutes=5)
+from .const import (
+    CONF_DOMAINS,
+    CONF_DUCK_TOKEN,
+    CONF_DYNU_TOKEN,
+    CONF_IPV4,
+    CONF_IPV6,
+    CONF_UPDATE_INTERVAL,
+    CONF_WILDCARD,
+    DEFAULT_IPV4,
+    DEFAULT_IPV6,
+    DEFAULT_SCAN_INTERVAL,
+    DEFAULT_UPDATE_INTERVAL,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,7 +38,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_IPV4, default=DEFAULT_IPV4): cv.string,
         vol.Optional(CONF_IPV6, default=DEFAULT_IPV6): cv.string,
         vol.Optional(CONF_WILDCARD, default=False): cv.boolean,
-        vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_INTERVAL): cv.time_period,
+        vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): cv.time_period,
     }
 )
 
@@ -44,6 +47,15 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     """Set up the Multi-DDNS sensor platform."""
     scan_interval: timedelta = config[CONF_SCAN_INTERVAL]
     async_add_entities([MultiDDNSSensor(hass, config, scan_interval)], True)
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up Multi-DDNS sensor from a config entry."""
+    config = {**entry.data, **entry.options}
+    interval = timedelta(
+        minutes=config.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
+    )
+    async_add_entities([MultiDDNSSensor(hass, config, interval)], True)
 
 
 class MultiDDNSSensor(SensorEntity):


### PR DESCRIPTION
## Summary
- Add Home Assistant config flow and options to configure Multi-DDNS via the UI
- Consolidate shared constants and enable config entry setup
- Document new UI-driven setup process

## Testing
- `pytest`
- `python -m py_compile custom_components/multiddns/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68b58265aed48330bb5c45fcf04dd41d