### PR TITLE
Fix platform setup and support multiline domains

### DIFF
--- a/custom_components/multiddns/__init__.py
+++ b/custom_components/multiddns/__init__.py
@@ -9,8 +9,11 @@ from pathlib import Path
 
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
 
 from .const import DOMAIN
+
+PLATFORMS = [Platform.SENSOR]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -69,10 +72,10 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Multi-DDNS from a config entry."""
-    await hass.config_entries.async_forward_entry_setup(entry, "sensor")
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a Multi-DDNS config entry."""
-    return await hass.config_entries.async_forward_entry_unload(entry, "sensor")
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)


### PR DESCRIPTION
## Summary
- fix integration setup to use new HA platform forwarding APIs
- allow comma- or newline-separated domain entries in a multiline text selector

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b59818321883308bc191bfa7324421