### PR TITLE
Add GitHub release workflow and initialize versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,15 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,3 +11,5 @@
 - Implemented Dynu and DuckDNS update logic within sensor platform.
 ## 2025-09-04
 - Added certbot service to generate and store SSL certificates.
+## 2025-09-05
+- Introduced GitHub release workflow and initialized versioning at 0.1.0.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ data:
 - `custom_components/multiddns/` – Integration source code
 - `hacs.json` – HACS metadata
 
+## Versioning
+
+This integration uses GitHub releases for versioning. Tagging a commit with a
+`v*` tag (for example, `v0.1`) triggers an automated workflow that publishes a
+GitHub release. The integration's current version is `0.1.0` as defined in the
+[`manifest.json`](custom_components/multiddns/manifest.json).
+
 ## License
 
 [MIT](LICENSE)

--- a/custom_components/multiddns/manifest.json
+++ b/custom_components/multiddns/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "multiddns",
   "name": "Multi-DDNS",
-  "version": "0.3.0",
+  "version": "0.1.0",
   "documentation": "https://github.com/CaseyRo/dynudns",
   "requirements": [],
   "codeowners": ["@CaseyRo"],


### PR DESCRIPTION
## Summary
- add workflow to publish GitHub releases when tags are pushed
- set integration version to 0.1.0
- document release-based versioning

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b59898e3948330a92a00bfae23462d